### PR TITLE
Add route to list devices per brand

### DIFF
--- a/src/Controller/BrandController.php
+++ b/src/Controller/BrandController.php
@@ -18,15 +18,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class BrandController extends AbstractController
 {
-    public function __construct()
-    {
-        try {
-            $this->denyAccessUnlessGranted(DeviceVoter::VIEW);
-        } catch (AccessDeniedException $e) {
-            throw new HttpException(403, "Your company cannot use the API.");
-        }
-    }
-
     /**
      * @Route("/", name=".index", methods={"GET"})
      */
@@ -34,6 +25,8 @@ class BrandController extends AbstractController
         BrandService $brandService,
         Request $request
     ): JsonResponse {
+        $this->checkAccessGranted();
+
         $paginationDTO = new PaginationDTO(
             $request->query->getInt('page', 1),
             $request->query->getInt('pageSize', 10)
@@ -55,11 +48,22 @@ class BrandController extends AbstractController
      */
     public function show(Brand $brand): JsonResponse
     {
+        $this->checkAccessGranted();
+
         return $this->json(
             $brand,
             200,
             [],
             ['groups' => 'brand.show']
         );
+    }
+
+    private function checkAccessGranted(): void
+    {
+        try {
+            $this->denyAccessUnlessGranted(DeviceVoter::VIEW);
+        } catch (AccessDeniedException $e) {
+            throw new HttpException(403, "Your company cannot use the API.");
+        }
     }
 }

--- a/src/Controller/BrandController.php
+++ b/src/Controller/BrandController.php
@@ -58,6 +58,32 @@ class BrandController extends AbstractController
         );
     }
 
+    /**
+     * @Route("/{id}/devices", name=".devices", methods={"GET"})
+     */
+    public function devices(
+        Brand $brand,
+        BrandService $brandService,
+        Request $request
+    ): JsonResponse {
+        $this->checkAccessGranted();
+
+        $paginationDTO = new PaginationDTO(
+            $request->query->getInt('page', 1),
+            $request->query->getInt('pageSize', 10)
+        );
+
+        return $this->json(
+            $brandService->findDevices($brand, $paginationDTO),
+            200,
+            [],
+            [
+                'groups' => 'brand.devices',
+                'pagination' => $paginationDTO,
+            ]
+        );
+    }
+
     private function checkAccessGranted(): void
     {
         try {

--- a/src/Controller/DeviceController.php
+++ b/src/Controller/DeviceController.php
@@ -18,15 +18,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class DeviceController extends AbstractController
 {
-    public function __construct()
-    {
-        try {
-            $this->denyAccessUnlessGranted(DeviceVoter::VIEW);
-        } catch (AccessDeniedException $e) {
-            throw new HttpException(403, "Your company cannot use the API.");
-        }
-    }
-
     /**
      * @Route("/", name=".index", methods={"GET"})
      */
@@ -34,6 +25,8 @@ class DeviceController extends AbstractController
         DeviceService $deviceService,
         Request $request
     ): JsonResponse {
+        $this->checkAccessGranted();
+
         $paginationDTO = new PaginationDTO(
             $request->query->getInt('page', 1),
             $request->query->getInt('pageSize', 10)
@@ -55,11 +48,22 @@ class DeviceController extends AbstractController
      */
     public function show(Device $device): JsonResponse
     {
+        $this->checkAccessGranted();
+
         return $this->json(
             $device,
             200,
             [],
             ['groups' => 'device.show']
         );
+    }
+
+    private function checkAccessGranted(): void
+    {
+        try {
+            $this->denyAccessUnlessGranted(DeviceVoter::VIEW);
+        } catch (AccessDeniedException $e) {
+            throw new HttpException(403, "Your company cannot use the API.");
+        }
     }
 }

--- a/src/Entity/Device.php
+++ b/src/Entity/Device.php
@@ -17,7 +17,7 @@ class Device
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
-     * @Groups({"device.index", "brand.show"})
+     * @Groups({"device.index", "brand.show", "brand.devices"})
      */
     private ?int $id = null;
 
@@ -30,13 +30,13 @@ class Device
 
     /**
      * @ORM\Column(type="string", length=255)
-     * @Groups({"device.index", "device.show", "brand.show"})
+     * @Groups({"device.index", "device.show", "brand.show", "brand.devices"})
      */
     private ?string $model = null;
 
     /**
      * @ORM\Column(type="string", length=255)
-     * @Groups({"device.index", "device.show", "brand.show"})
+     * @Groups({"device.index", "device.show", "brand.show", "brand.devices"})
      */
     private ?string $type = null;
 

--- a/src/Repository/DeviceRepository.php
+++ b/src/Repository/DeviceRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Brand;
 use App\Entity\Device;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -28,6 +29,20 @@ class DeviceRepository extends ServiceEntityRepository
             ->leftJoin('d.brand', 'b')
             ->select('d', 'b')
             ->orderBy('d.id', 'ASC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->setHint(Paginator::HINT_ENABLE_DISTINCT, false);
+
+        return new Paginator($query);
+    }
+
+    public function findDevicesFromBand(Brand $brand, int $page, int $limit): Paginator
+    {
+        $query = $this->createQueryBuilder('d')
+            ->leftJoin('d.brand', 'b')
+            ->where('d.brand = :brand')
+            ->setParameter('brand', $brand)
             ->setFirstResult(($page - 1) * $limit)
             ->setMaxResults($limit)
             ->getQuery()

--- a/src/Service/BrandService.php
+++ b/src/Service/BrandService.php
@@ -3,16 +3,22 @@
 namespace App\Service;
 
 use App\DTO\PaginationDTO;
+use App\Entity\Brand;
 use App\Repository\BrandRepository;
+use App\Repository\DeviceRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
 class BrandService
 {
     private BrandRepository $brandRepository;
+    private DeviceRepository $deviceRepository;
 
-    public function __construct(BrandRepository $brandRepository)
-    {
+    public function __construct(
+        BrandRepository $brandRepository,
+        DeviceRepository $deviceRepository
+    ) {
         $this->brandRepository = $brandRepository;
+        $this->deviceRepository = $deviceRepository;
     }
 
     /**
@@ -25,6 +31,22 @@ class BrandService
     public function findPage(PaginationDTO $paginationDTO): Paginator
     {
         return $this->brandRepository->findPage(
+            $paginationDTO->page,
+            $paginationDTO->pageSize
+        );
+    }
+
+    /**
+     * Finds the devices of a brand.
+     *
+     * @param Brand $brand The brand.
+     * 
+     * @return Paginator The devices.
+     */
+    public function findDevices(Brand $brand, PaginationDTO $paginationDTO): Paginator
+    {
+        return $this->deviceRepository->findDevicesFromBand(
+            $brand,
             $paginationDTO->page,
             $paginationDTO->pageSize
         );


### PR DESCRIPTION
Added the route /brands/{id}/devices to show the devices for a specific brand.

Also, fixed the access verification.