### PR TITLE
Update login route and remove company notation

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -69,6 +69,10 @@ when@test:
             # important to generate secure password hashes. In tests however, secure hashes
             # are not important, waste resources and increase test times. The following
             # reduces the work factor to the lowest possible values.
+            App\Entity\User:
+                algorithm: md5
+                encode_as_base64: false
+                iterations: 0
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
                 algorithm: auto
                 cost: 4 # Lowest possible value for bcrypt

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -46,6 +46,22 @@ security:
         - { path: ^/api/, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/api, roles: PUBLIC_ACCESS }
 
+when@dev:
+    security:
+        password_hashers:
+            # By default, password hashers are resource intensive and take time. In development
+            # however, secure hashes are not important, waste resources and increase test times.
+            # The following reduces the work factor to the lowest possible values.
+            App\Entity\User:
+                algorithm: md5
+                encode_as_base64: false
+                iterations: 0
+            Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+                algorithm: auto
+                cost: 4 # Lowest possible value for bcrypt
+                time_cost: 3 # Lowest possible value for argon
+                memory_cost: 10 # Lowest possible value for argon
+
 when@test:
     security:
         password_hashers:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -16,10 +16,10 @@ security:
             security: false
 
         login:
-            pattern: ^/api/login
+            pattern: ^/api/login$
             stateless: true
             json_login:
-                check_path: /api/login_check
+                check_path: /api/login
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -19,7 +19,7 @@ security:
             pattern: ^/api/login$
             stateless: true
             json_login:
-                check_path: /api/login
+                check_path: api.login
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,4 +3,4 @@
 #    controller: App\Controller\DefaultController::index
 
 api_login_check:
-    path: /api/login_check
+    path: /api/login

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -2,6 +2,6 @@
 #    path: /
 #    controller: App\Controller\DefaultController::index
 
-api_login_check:
+api.login:
     path: /api/login
     methods: ["POST"]

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -4,3 +4,4 @@
 
 api_login_check:
     path: /api/login
+    methods: ["POST"]

--- a/migrations/Version20240518150412.php
+++ b/migrations/Version20240518150412.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240518150412 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user DROP FOREIGN KEY FK_8D93D649979B1AD6');
+        $this->addSql('DROP INDEX IDX_8D93D649979B1AD6 ON user');
+        $this->addSql('ALTER TABLE user CHANGE company_id customer_id INT NOT NULL');
+        $this->addSql('ALTER TABLE user ADD CONSTRAINT FK_8D93D6499395C3F3 FOREIGN KEY (customer_id) REFERENCES customer (id)');
+        $this->addSql('CREATE INDEX IDX_8D93D6499395C3F3 ON user (customer_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user DROP FOREIGN KEY FK_8D93D6499395C3F3');
+        $this->addSql('DROP INDEX IDX_8D93D6499395C3F3 ON user');
+        $this->addSql('ALTER TABLE user CHANGE customer_id company_id INT NOT NULL');
+        $this->addSql('ALTER TABLE user ADD CONSTRAINT FK_8D93D649979B1AD6 FOREIGN KEY (company_id) REFERENCES customer (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+        $this->addSql('CREATE INDEX IDX_8D93D649979B1AD6 ON user (company_id)');
+    }
+}

--- a/src/Controller/BrandController.php
+++ b/src/Controller/BrandController.php
@@ -79,7 +79,7 @@ class BrandController extends BaseController
      */
     public function index(BrandService $brandService, Request $request): JsonResponse
     {
-        $this->checkAccessGranted(DeviceVoter::VIEW, null, "Your company cannot use the API.");
+        $this->checkAccessGranted(DeviceVoter::VIEW, null, "The customer you are attached to cannot use the API.");
 
         $page = $request->query->getInt('page', 1);
         $pageSize = $request->query->getInt('pageSize', 10);
@@ -121,7 +121,7 @@ class BrandController extends BaseController
      */
     public function show(Brand $brand): JsonResponse
     {
-        $this->checkAccessGranted(DeviceVoter::VIEW, null, "Your company cannot use the API.");
+        $this->checkAccessGranted(DeviceVoter::VIEW, null, "The customer you are attached to cannot use the API.");
 
         $cacheKey = "brand_{$brand->getId()}";
 
@@ -188,7 +188,7 @@ class BrandController extends BaseController
         BrandService $brandService,
         Request $request
     ): JsonResponse {
-        $this->checkAccessGranted(DeviceVoter::VIEW, null, "Your company cannot use the API.");
+        $this->checkAccessGranted(DeviceVoter::VIEW, null, "The customer you are attached to cannot use the API.");
 
         $page = $request->query->getInt('page', 1);
         $pageSize = $request->query->getInt('pageSize', 10);

--- a/src/Controller/DeviceController.php
+++ b/src/Controller/DeviceController.php
@@ -80,7 +80,7 @@ class DeviceController extends BaseController
         DeviceService $deviceService,
         Request $request
     ): JsonResponse {
-        $this->checkAccessGranted(DeviceVoter::VIEW, null, "Your company cannot use the API.");
+        $this->checkAccessGranted(DeviceVoter::VIEW, null, "The customer you are attached to cannot use the API.");
 
         $page = $request->query->getInt('page', 1);
         $pageSize = $request->query->getInt('pageSize', 10);
@@ -125,7 +125,7 @@ class DeviceController extends BaseController
      */
     public function show(Device $device): JsonResponse
     {
-        $this->checkAccessGranted(DeviceVoter::VIEW, null, "Your company cannot use the API.");
+        $this->checkAccessGranted(DeviceVoter::VIEW, null, "The customer you are attached to cannot use the API.");
 
         $cacheKey = "device_{$device->getId()}";
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -95,16 +95,16 @@ class UserController extends BaseController
         $page = $request->query->getInt('page', 1);
         $pageSize = $request->query->getInt('pageSize', 10);
 
-        $company = $this->user->getCompany();
+        $customer = $this->user->getCustomer();
 
-        $cacheKey = "users_{$company->getId()}_{$page}_{$pageSize}";
+        $cacheKey = "users_{$customer->getId()}_{$page}_{$pageSize}";
 
-        $serializedUsers = $this->cache->get($cacheKey, function (ItemInterface $item) use ($userService, $company, $page, $pageSize) {
+        $serializedUsers = $this->cache->get($cacheKey, function (ItemInterface $item) use ($userService, $customer, $page, $pageSize) {
             $item->tag(['users']);
 
             $paginationDTO = new PaginationDTO($page, $pageSize);
 
-            $users = $userService->findPage($paginationDTO, $company);
+            $users = $userService->findPage($paginationDTO, $customer);
 
             $context = SerializationContext::create()
                 ->setGroups([
@@ -141,7 +141,7 @@ class UserController extends BaseController
      */
     public function show(User $user): JsonResponse
     {
-        $this->checkAccessGranted(UserVoter::VIEW, $user, "You cannot view another company's users");
+        $this->checkAccessGranted(UserVoter::VIEW, $user, "You cannot view another customer's users");
 
         $cacheKey = "user_{$user->getId()}";
 
@@ -265,7 +265,7 @@ class UserController extends BaseController
         SerializerInterface $serializer,
         UserService $userService
     ): JsonResponse {
-        $this->checkAccessGranted(UserVoter::UPDATE, $user, "You cannot update another company's users");
+        $this->checkAccessGranted(UserVoter::UPDATE, $user, "You cannot update another customer's users");
 
         /** @var UserDTO */
         $userDTO = $serializer->deserialize($request->getContent(), UserDTO::class, 'json');
@@ -315,7 +315,7 @@ class UserController extends BaseController
         User $user,
         EntityManagerInterface $entityManager
     ): JsonResponse {
-        $this->checkAccessGranted(UserVoter::DELETE, $user, "You cannot delete another company's users");
+        $this->checkAccessGranted(UserVoter::DELETE, $user, "You cannot delete another customer's users");
 
         $entityManager->remove($user, true);
         $entityManager->flush();

--- a/src/DTO/UserDTO.php
+++ b/src/DTO/UserDTO.php
@@ -49,18 +49,18 @@ class UserDTO
      */
     private ?string $password = null;
 
-    private ?Customer $company = null;
+    private ?Customer $customer = null;
 
     public function __construct(
         ?string $email = null,
         ?string $fullname = null,
         ?string $password = null,
-        ?Customer $company = null
+        ?Customer $customer = null
     ) {
         $this->email = $email;
         $this->fullname = $fullname;
         $this->password = $password;
-        $this->company = $company;
+        $this->customer = $customer;
     }
 
     public function getId(): ?int
@@ -88,9 +88,9 @@ class UserDTO
         return $this->password;
     }
 
-    public function getCompany(): ?Customer
+    public function getCustomer(): ?Customer
     {
-        return $this->company;
+        return $this->customer;
     }
 
     public function eraseCredentials(): void

--- a/src/DataFixtures/UserFixture.php
+++ b/src/DataFixtures/UserFixture.php
@@ -14,7 +14,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserFixture extends Fixture
 {
-    private array $companyNames = [];
+    private array $customerNames = [];
     private UserPasswordHasherInterface $passwordHasher;
 
     public function __construct(UserPasswordHasherInterface $passwordHasher)
@@ -47,11 +47,11 @@ class UserFixture extends Fixture
         for ($i = 0; $i < 3; $i++) {
             $customer = (new Customer())
                 ->setName($faker->company)
-                ->setCanUseApi($faker->boolean);
+                ->setCanUseApi(true);
 
             $this->addReference("customer-" . $customer->getName(), $customer);
 
-            array_push($this->companyNames, $customer->getName());
+            array_push($this->customerNames, $customer->getName());
 
             yield $customer;
         }
@@ -67,7 +67,7 @@ class UserFixture extends Fixture
         // Persistant users for testing
         $user1 = (new User())
             ->setEmail("user1@example.com")
-            ->setCompany($this->getReference("customer-" . $this->companyNames[0]))
+            ->setCustomer($this->getReference("customer-" . $this->customerNames[0]))
             ->setFullname("John Doe");
         $user1->setPassword($this->passwordHasher->hashPassword($user1, "password"));
 
@@ -75,17 +75,17 @@ class UserFixture extends Fixture
 
         $user2 = (new User())
             ->setEmail("user2@example.com")
-            ->setCompany($this->getReference("customer-" . $this->companyNames[1]))
+            ->setCustomer($this->getReference("customer-" . $this->customerNames[1]))
             ->setFullname("Jane Doe");
         $user2->setPassword($this->passwordHasher->hashPassword($user2, "password"));
 
         yield $user2;
 
-        foreach ($this->companyNames as $companyName) {
+        foreach ($this->customerNames as $customerName) {
             for ($i = 0; $i < 15; $i++) {
                 $user = (new User())
                     ->setEmail($faker->email)
-                    ->setCompany($this->getReference("customer-" . $companyName))
+                    ->setCustomer($this->getReference("customer-" . $customerName))
                     ->setFullname($faker->name);
                 $user->setPassword($this->passwordHasher->hashPassword($user, $faker->password));
 

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -47,7 +47,7 @@ class Customer
     private bool $canUseApi = true;
 
     /**
-     * @ORM\OneToMany(mappedBy="company", targetEntity=User::class, orphanRemoval=true)
+     * @ORM\OneToMany(mappedBy="customer", targetEntity=User::class, orphanRemoval=true)
      */
     private Collection $users;
 
@@ -97,7 +97,7 @@ class Customer
     {
         if (!$this->users->contains($user)) {
             $this->users[] = $user;
-            $user->setCompany($this);
+            $user->setCustomer($this);
         }
 
         return $this;
@@ -107,8 +107,8 @@ class Customer
     {
         if ($this->users->removeElement($user)) {
             // set the owning side to null (unless already changed)
-            if ($user->getCompany() === $this) {
-                $user->setCompany(null);
+            if ($user->getCustomer() === $this) {
+                $user->setCustomer(null);
             }
         }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -63,7 +63,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @ORM\Column(type="string", length=255)
      * @Groups({"user.index", "user.show", "user.create", "user.update"})
      */
-    private $fullname;
+    private ?string $fullname = null;
 
     /**
      * @ORM\ManyToOne(targetEntity=Customer::class, inversedBy="users")

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -70,7 +70,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @ORM\JoinColumn(nullable=false)
      * @Groups({"user.show"})
      */
-    private ?Customer $company = null;
+    private ?Customer $customer = null;
 
     /**
      * @ORM\Column(type="json")
@@ -132,14 +132,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return (string) $this->email;
     }
 
-    public function getCompany(): ?Customer
+    public function getCustomer(): ?Customer
     {
-        return $this->company;
+        return $this->customer;
     }
 
-    public function setCompany(?Customer $company): self
+    public function setCustomer(?Customer $customer): self
     {
-        $this->company = $company;
+        $this->customer = $customer;
 
         return $this;
     }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -63,14 +63,14 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $this->add($user, true);
     }
 
-    public function findPage(int $page, int $limit, Customer $company): PaginationInterface
+    public function findPage(int $page, int $limit, Customer $customer): PaginationInterface
     {
         $paginator = $this->paginator->paginate(
             $this->createQueryBuilder('u')
-                ->leftJoin('u.company', 'c')
+                ->leftJoin('u.customer', 'c')
                 ->select('u', 'c')
-                ->where('c = :company')
-                ->setParameter('company', $company)
+                ->where('c = :customer')
+                ->setParameter('customer', $customer)
                 ->orderBy('u.id', 'ASC')
                 ->getQuery()
                 ->setHint(Paginator::HINT_ENABLE_DISTINCT, false),

--- a/src/Security/Voter/DeviceVoter.php
+++ b/src/Security/Voter/DeviceVoter.php
@@ -45,7 +45,7 @@ class DeviceVoter extends Voter
 
     private function canView(User $user): bool
     {
-        // A user can view devices if their company has the right to use the API
-        return $user->getCompany()->canUseApi();
+        // A user can view devices if the attached customer has the right to use the API
+        return $user->getCustomer()->canUseApi();
     }
 }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -64,8 +64,8 @@ class UserVoter extends Voter
 
     private function canView(User $user, User $subject): bool
     {
-        // A user can view another user if they are part of the same company
-        return $user->getCompany() === $subject->getCompany();
+        // A user can view another user if they belong to the same customer
+        return $user->getCustomer() === $subject->getCustomer();
     }
 
     private function canCreate(User $user): bool
@@ -76,13 +76,13 @@ class UserVoter extends Voter
 
     private function canUpdate(User $user, User $subject): bool
     {
-        // A user can update another user if they are part of the same company
-        return $user->getCompany() === $subject->getCompany();
+        // A user can update another user if they belong to the same customer
+        return $user->getCustomer() === $subject->getCustomer();
     }
 
     private function canDelete(User $user, User $subject): bool
     {
-        // A user can delete another user if they are part of the same company
-        return $user->getCompany() === $subject->getCompany();
+        // A user can delete another user if they belong to the same customer
+        return $user->getCustomer() === $subject->getCustomer();
     }
 }

--- a/src/Serializer/Normalizer/UserNormalizer.php
+++ b/src/Serializer/Normalizer/UserNormalizer.php
@@ -28,10 +28,12 @@ class UserNormalizer implements ContextAwareNormalizerInterface, DenormalizerInt
 
     public function normalize($user, ?string $format = null, array $context = [])
     {
+        /** @var User $user */
+
         $data = $this->normalizer->normalize($user, $format, $context);
 
         // Here, add, edit, or delete some data:
-        $data["company"] = $user->getCompany()->getName();
+        $data["customer"] = $user->getCustomer()->getName();
 
         return $data;
     }
@@ -45,7 +47,7 @@ class UserNormalizer implements ContextAwareNormalizerInterface, DenormalizerInt
             $data['email'] ?? null,
             $data['fullname'] ?? null,
             $data['password'] ?? null,
-            $currentUser->getCompany()
+            $currentUser->getCustomer()
         );
 
         return $userDTO;

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -55,7 +55,7 @@ class UserService
             $userDTO->eraseCredentials();
         }
 
-        $user->setCompany($userDTO->getCompany());
+        $user->setCustomer($userDTO->getCustomer());
 
         return $user;
     }
@@ -67,12 +67,12 @@ class UserService
      * 
      * @return PaginationInterface The users.
      */
-    public function findPage(PaginationDTO $paginationDTO, Customer $company): PaginationInterface
+    public function findPage(PaginationDTO $paginationDTO, Customer $customer): PaginationInterface
     {
         return $this->userRepository->findPage(
             $paginationDTO->page,
             $paginationDTO->pageSize,
-            $company
+            $customer
         );
     }
 


### PR DESCRIPTION
Moved the login route from /api/login_check to /api/login.

Renamed all occurrences of "company" to "customer" to match the entity name and to reflect that the application should not be concerned of the nature of the relationship between a user and a customer (i.e. a user is not necessarily part of the customer's company).